### PR TITLE
ESP32: Workaround for faulty getaddrinfo() with ".local" adresses.

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -55,7 +55,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
     ai = ai[0]
 
-    s = usocket.socket(ai[0], ai[1], ai[2])
+    s = usocket.socket(ai[0], usocket.SOCK_STREAM, ai[2])
     try:
         s.connect(ai[-1])
         if proto == "https:":


### PR DESCRIPTION
On the ESP32, socket.getaddrinfo() might return SOCK_DGRAM instead of SOCK_STREAM.
As a HTTP request is always a TCP stream, we don't need to rely on the values returned by getaddrinfo.